### PR TITLE
Bugfix/rdd 494 add password secret manager

### DIFF
--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/Configuration/AwsSecretsManagerClient.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/Configuration/AwsSecretsManagerClient.cs
@@ -1,0 +1,57 @@
+﻿using System.Text.Json;
+using Amazon.SecretsManager;
+using Amazon;
+using Amazon.SecretsManager.Model;
+
+namespace NIHR.StudyManagement.Api.Configuration;
+
+public class AwsSecretsManagerClient
+{
+    private readonly RegionEndpoint _region;
+    private readonly string _secretName;
+
+    public AwsSecretsManagerClient(RegionEndpoint region, string secretName)
+    {
+        _region = region;
+        _secretName = secretName;
+    }
+
+    public Dictionary<string, string> Load()
+    {
+        var secret = GetSecret();
+
+        var data = JsonSerializer.Deserialize<Dictionary<string, string>>(secret);
+
+        return data;
+    }
+
+    private string GetSecret()
+    {
+        var request = new GetSecretValueRequest
+        {
+            SecretId = _secretName,
+            VersionStage = "AWSCURRENT" // VersionStage defaults to AWSCURRENT if unspecified.
+        };
+
+        using (var client =
+        new AmazonSecretsManagerClient(_region))
+        {
+            var response = client.GetSecretValueAsync(request).Result;
+
+            string secretString;
+            if (response.SecretString != null)
+            {
+                secretString = response.SecretString;
+            }
+            else
+            {
+                var memoryStream = response.SecretBinary;
+                var reader = new StreamReader(memoryStream);
+                secretString = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(reader.ReadToEnd()));
+            }
+
+            return secretString;
+        }
+    }
+}
+

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/Configuration/DatabaseSettings.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/Configuration/DatabaseSettings.cs
@@ -3,5 +3,7 @@
     public class DatabaseSettings
     {
         public string ConnectionString { get; set; } = $"";
+
+        public string PasswordSecretName { get; set; } = "";
     }
 }

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/NIHR.StudyManagement.Api.csproj
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/NIHR.StudyManagement.Api.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="8.1.1" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.302.28" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.26" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/Startup.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/Startup.cs
@@ -123,7 +123,7 @@ public class Startup
             {
                 connectionString = studyManagementApiSettings.Data.ConnectionString;
             }
-            Console.WriteLine($"DEBUG DELETE ME: {connectionString}");
+
             options.UseMySQL(connectionString);
         });
     }

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/Startup.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/Startup.cs
@@ -12,6 +12,7 @@ using MySql.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using System.Reflection;
+using Amazon;
 
 namespace NIHR.StudyManagement.Api;
 
@@ -105,7 +106,26 @@ public class Startup
         services.AddTransient<IGovernmentResearchIdentifierService, GovernmentResearchIdentifierService>();
         services.AddTransient<IGovernmentResearchIdentifierDtoMapper, GovernmentResearchIdentifierDtoMapper>();
 
-        services.AddDbContext<StudyRegistryContext>(options => options.UseMySQL(studyManagementApiSettings.Data.ConnectionString));
+        services.AddDbContext<StudyRegistryContext>(options =>
+        {
+            // For local development, username/password included in connection string.
+            // For deployed lambda in AWS, password is retrieved from secret manager
+            var connectionString = "";
+
+            if (!string.IsNullOrEmpty(studyManagementApiSettings.Data.PasswordSecretName))
+            {
+                // Retrieve password from AWS Secrets.
+                var password = GetAwsSecretPassword(studyManagementApiSettings.Data.PasswordSecretName);
+
+                connectionString = $"{studyManagementApiSettings.Data.ConnectionString};password={password}";
+            }
+            else
+            {
+                connectionString = studyManagementApiSettings.Data.ConnectionString;
+            }
+            Console.WriteLine($"DEBUG DELETE ME: {connectionString}");
+            options.UseMySQL(connectionString);
+        });
     }
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IOptions<StudyManagementApiSettings> studyManagementApiSettings)
@@ -198,5 +218,19 @@ public class Startup
                 return Task.CompletedTask;
             }
         };
+    }
+
+    private string GetAwsSecretPassword(string secretName)
+    {
+        var secretManager = new AwsSecretsManagerClient(RegionEndpoint.EUWest2, secretName);
+
+        var data = secretManager.Load();
+
+        if (data.ContainsKey("password"))
+        {
+            return data["password"];
+        }
+
+        return string.Empty;
     }
 }

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/appsettings.Development.json
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/appsettings.Development.json
@@ -13,7 +13,8 @@
       }
     },
     "Data": {
-      "ConnectionString": "<db connection string here>"
+      "ConnectionString": "<db connection string here>",
+      "PasswordSecretName": "<optional password secret name. If empty, password expected in connection string.>"
     }
   },
   "StudyManagement": {

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/serverless.template
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/serverless.template
@@ -53,7 +53,7 @@
               "Home": {
                 "Type": "Api",
                 "Properties": {
-                  "Path": "/api/v1/home",
+                  "Path": "/api/home",
                   "Method": "GET",
                   "RestApiId": { "Ref" : "StudyManagementApi" }
                 }
@@ -61,8 +61,32 @@
               "HomeAuthenticated": {
                 "Type": "Api",
                 "Properties": {
-                  "Path": "/api/v1/home/authenticated",
+                  "Path": "/api/home/authenticated",
                   "Method": "GET",
+                  "RestApiId": { "Ref" : "StudyManagementApi" }
+                }
+              },
+              "CreateIdentifier": {
+                "Type": "Api",
+                "Properties": {
+                  "Path": "/api/identifier/",
+                  "Method": "POST",
+                  "RestApiId": { "Ref" : "StudyManagementApi" }
+                }
+              },
+              "GetIdentifier": {
+                "Type": "Api",
+                "Properties": {
+                  "Path": "/api/identifier/{identifier}",
+                  "Method": "GET",
+                  "RestApiId": { "Ref" : "StudyManagementApi" }
+                }
+              },
+              "AddStudyToExistingIdentifier": {
+                "Type": "Api",
+                "Properties": {
+                  "Path": "/api/identifier/{identifier}",
+                  "Method": "PATCH",
                   "RestApiId": { "Ref" : "StudyManagementApi" }
                 }
               }


### PR DESCRIPTION
The initial intention was to use IAM policies to access the MySql instance, however this didn't work as intended and it has been decided to, in the short term for the PoC, use a connection string with conventional username/password authentication.

Therefore we need to add a new bit of code to retrieve the password from AWS secrets.