### PR TITLE
RDD-797: Study Management API - Convert the operation that registers a new local system identifier to an existing GRIS study identifier, to be FHIR.

### DIFF
--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/Controllers/ApiControllerBase.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/Controllers/ApiControllerBase.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using NIHR.StudyManagement.Api.EnumsAndConstants;
 
 namespace NIHR.StudyManagement.Api.Controllers
 {
@@ -11,6 +12,22 @@ namespace NIHR.StudyManagement.Api.Controllers
         {
 
             return Ok();
+        }
+
+        protected string ApiConsumerSystemName
+        {
+            get
+            {
+                foreach (var userClaim in this.User.Claims)
+                {
+                    if (userClaim.Type == UserTokenClaimNames.ApiSystemName)
+                    {
+                        return userClaim.Value;
+                    }
+                }
+
+                return "";
+            }
         }
     }
 }

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/Documentation/RegisterNewStudyBundleRequestExampleV1.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/Documentation/RegisterNewStudyBundleRequestExampleV1.cs
@@ -1,4 +1,5 @@
 ﻿using Hl7.Fhir.Model;
+using NIHR.StudyManagement.Domain.EnumsAndConstants;
 using NIHR.StudyManagement.Infrastructure.Repository.EnumsAndConstants;
 using Swashbuckle.AspNetCore.Filters;
 

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/EnumsAndConstants/UserTokenClaimNames.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/EnumsAndConstants/UserTokenClaimNames.cs
@@ -1,0 +1,7 @@
+﻿namespace NIHR.StudyManagement.Api.EnumsAndConstants
+{
+    public class UserTokenClaimNames
+    {
+        public const string ApiSystemName = "ApiSystemName";
+    }
+}

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/ExtensionMethods/FhirExtensionMethods.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/ExtensionMethods/FhirExtensionMethods.cs
@@ -1,0 +1,51 @@
+﻿using Hl7.Fhir.Model;
+using NIHR.StudyManagement.Api.Models;
+
+namespace NIHR.StudyManagement.Api.ExtensionMethods
+{
+    public static class FhirExtensionMethods
+    {
+        public static void AddNewEntryComponent(this Bundle bundle,
+            Resource resource,
+            HttpRequestResponseFhirContext httpRequestResponseFhirContext)
+        {
+            var bundleRequestContext = new Bundle.RequestComponent
+            {
+                Method = MapToBundleHttpVerb(httpRequestResponseFhirContext.Method),
+                Url = httpRequestResponseFhirContext.Url
+            };
+
+            var bundleResponseContext = new Bundle.ResponseComponent
+            {
+                Status = httpRequestResponseFhirContext.Status.ToString()
+            };
+
+            if(bundle.Entry == null)
+            {
+                bundle.Entry = new List<Bundle.EntryComponent>();
+            }
+
+            bundle.Entry.Add(new Bundle.EntryComponent()
+            {
+                Resource = resource,
+                Response = bundleResponseContext,
+                Request = bundleRequestContext
+            });
+        }
+
+        private static Bundle.HTTPVerb MapToBundleHttpVerb(HttpMethod httpMethod)
+        {
+            return httpMethod == HttpMethod.Get
+                ? Bundle.HTTPVerb.GET
+                : httpMethod == HttpMethod.Delete
+                ? Bundle.HTTPVerb.DELETE
+                : httpMethod == HttpMethod.Post
+                ? Bundle.HTTPVerb.POST
+                : httpMethod == HttpMethod.Put
+                ? Bundle.HTTPVerb.PUT
+                : httpMethod == HttpMethod.Patch
+                ? Bundle.HTTPVerb.PATCH
+                : Bundle.HTTPVerb.HEAD;
+        }
+    }
+}

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/Mappers/GovernmentResearchIdentifierDtoMapper.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/Mappers/GovernmentResearchIdentifierDtoMapper.cs
@@ -29,27 +29,6 @@ namespace NIHR.StudyManagement.Api.Mappers
             return createIdentifierRequest;
         }
 
-        public RegisterStudyRequest Map(RegisterStudyRequestDto requestDto)
-        {
-            var chiefInvestigatorPerson = requestDto.TeamMembers.First();
-
-            var createIdentifierRequest = new RegisterStudyRequest()
-            {
-                ShortTitle = requestDto.LocalStudy.ShortTitle,
-                ProjectId = requestDto.LocalStudy.ProjectId,
-                ProtocolId = requestDto.ProtocolId,
-                ChiefInvestigator = new PersonWithPrimaryEmail
-                {
-                    Email = new Email { Address = chiefInvestigatorPerson.PrimaryEmail},
-                    Firstname = chiefInvestigatorPerson.Firstname,
-                    Lastname = chiefInvestigatorPerson.Lastname
-                },
-                StatusCode = requestDto.LocalStudy.Status
-            };
-
-            return createIdentifierRequest;
-        }
-
         public GovernmentResearchIdentifierDto Map(GovernmentResearchIdentifier governmentResearchIdentifier)
         {
             var identifier = new GovernmentResearchIdentifierDto

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/Mappers/IFhirMapper.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/Mappers/IFhirMapper.cs
@@ -1,12 +1,13 @@
 ﻿using Hl7.Fhir.Model;
+using NIHR.StudyManagement.Api.Models;
 using NIHR.StudyManagement.Domain.Models;
 
 namespace NIHR.StudyManagement.Api.Mappers
 {
     public interface IFhirMapper
     {
-        RegisterStudyRequest MapCreateRequestBundle(Bundle bundle);
+        RegisterStudyRequest MapCreateRequestBundle(Bundle bundle, string apiSystemName, string identifier);
 
-        Bundle MapToResearchStudyBundle(GovernmentResearchIdentifier governmentResearchIdentifier);
+        Bundle MapToResearchStudyBundle(GovernmentResearchIdentifier governmentResearchIdentifier, HttpRequestResponseFhirContext httpRequestResponseFhirContext);
     }
 }

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/Mappers/IGovernmentResearchIdentifierDtoMapper.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/Mappers/IGovernmentResearchIdentifierDtoMapper.cs
@@ -5,8 +5,6 @@ namespace NIHR.StudyManagement.Api.Mappers
 {
     public interface IGovernmentResearchIdentifierDtoMapper
     {
-        RegisterStudyRequest Map(RegisterStudyRequestDto requestDto);
-
         RegisterStudyToExistingIdentifierRequest Map(RegisterStudyRequestDto requestDto, string identifier);
 
         GovernmentResearchIdentifierDto Map(GovernmentResearchIdentifier governmentResearchIdentifier);

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Api/Models/HttpRequestResponseFhirContext.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Api/Models/HttpRequestResponseFhirContext.cs
@@ -1,0 +1,10 @@
+﻿namespace NIHR.StudyManagement.Api.Models
+{
+    public class HttpRequestResponseFhirContext
+    {
+        public HttpMethod Method { get; set; }
+        public string Url { get; set; }
+
+        public int Status { get; set; }
+    }
+}

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Domain/EnumsAndConstants/FhirResourceAttributeDescriptions.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Domain/EnumsAndConstants/FhirResourceAttributeDescriptions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NIHR.StudyManagement.Domain.EnumsAndConstants
+{
+    public class FhirResourceAttributeDescriptions
+    {
+        public const string LabelShortTitle = "Short Title";
+    }
+}

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Domain/EnumsAndConstants/ResearchInitiativeIdentifierTypes.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Domain/EnumsAndConstants/ResearchInitiativeIdentifierTypes.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace NIHR.StudyManagement.Infrastructure.Repository.EnumsAndConstants
+namespace NIHR.StudyManagement.Domain.EnumsAndConstants
 {
     public class ResearchInitiativeIdentifierTypes
     {

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Domain/Models/AddStudyToExistingIdentifierRequestWithContext.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Domain/Models/AddStudyToExistingIdentifierRequestWithContext.cs
@@ -1,6 +1,18 @@
 ﻿namespace NIHR.StudyManagement.Domain.Models
 {
-    public class AddStudyToExistingIdentifierRequestWithContext : RegisterStudyRequestWithContext
+    public class AddStudyToExistingIdentifierRequestWithContext
     {
+        public RegisterStudyToExistingIdentifierRequest RequestContext { get; set; }
+
+        public List<LinkedSystemIdentifier> LinkedSystemIdentifiersToAdd { get; set; }
+
+        public List<TeamMember> TeamMembersToAdd { get; set; }
+
+        public AddStudyToExistingIdentifierRequestWithContext()
+        {
+            RequestContext = new RegisterStudyToExistingIdentifierRequest();
+            LinkedSystemIdentifiersToAdd = new List<LinkedSystemIdentifier>();
+            TeamMembersToAdd = new List<TeamMember>();
+        }
     }
 }

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Domain/Models/RegisterStudyRequest.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Domain/Models/RegisterStudyRequest.cs
@@ -15,6 +15,8 @@
 
         public string StatusCode { get; set; }
 
+        public string ApiSystemName { get; set; }
+
         public List<ResearchInitiativeIdentifierItem> Identifiers { get; set; }
 
         public RegisterStudyRequest()

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Domain/Models/RegisterStudyRequestWithContext.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Domain/Models/RegisterStudyRequestWithContext.cs
@@ -2,8 +2,6 @@
 {
     public class RegisterStudyRequestWithContext : RegisterStudyRequest
     {
-        public string LocalSystemName {get;set;}
-
         public string RoleName { get; set; }
 
         public string Identifier { get; set; }
@@ -15,7 +13,6 @@
         public RegisterStudyRequestWithContext()
         {
             Identifier = "";
-            LocalSystemName = "";
             RoleName = "";
             EffectiveFrom = DateTime.Now;
             StatusCode = "";

--- a/NIHR.StudyManagement/NIHR.StudyManagement.Infrastructure/Repository/StudyRegistryContext.cs
+++ b/NIHR.StudyManagement/NIHR.StudyManagement.Infrastructure/Repository/StudyRegistryContext.cs
@@ -299,9 +299,9 @@ namespace NIHR.StudyManagement.Infrastructure.Repository
                     .HasColumnName("description");
 
                 entity.HasData(
-                    new ResearchInitiativeIdentifierType { Id = 1, Description = EnumsAndConstants.ResearchInitiativeIdentifierTypes.Project },
-                    new ResearchInitiativeIdentifierType { Id = 2, Description = EnumsAndConstants.ResearchInitiativeIdentifierTypes.Protocol },
-                    new ResearchInitiativeIdentifierType { Id = 3, Description = EnumsAndConstants.ResearchInitiativeIdentifierTypes.Bundle }
+                    new ResearchInitiativeIdentifierType { Id = 1, Description = Domain.EnumsAndConstants.ResearchInitiativeIdentifierTypes.Project },
+                    new ResearchInitiativeIdentifierType { Id = 2, Description = Domain.EnumsAndConstants.ResearchInitiativeIdentifierTypes.Protocol },
+                    new ResearchInitiativeIdentifierType { Id = 3, Description = Domain.EnumsAndConstants.ResearchInitiativeIdentifierTypes.Bundle }
                     );
             });
 


### PR DESCRIPTION
The changes here are to modify the FHIR endpoint to support adding a new external system identifier to a known GRIS identifier. The changes are based on how we understand the requirements to date, but realistically the functionality is subject to change.